### PR TITLE
Correct public key generation function name in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ cryptographic source:
 To generate a public key:
 
 	ed25519_public_key pk;
-	ed25519_public_key(sk, pk);
+	ed25519_publickey(sk, pk);
 
 To sign a message:
 


### PR DESCRIPTION
`ed25519_public_key` is the type, `ed25519_publickey` is the function.
Let me be the last one to waste time chasing this.
