### PR TITLE
Fix compilation with ED25519_SUFFIX defined

### DIFF
--- a/ed25519-donna-batchverify.h
+++ b/ed25519-donna-batchverify.h
@@ -213,7 +213,7 @@ ED25519_FN(ed25519_sign_open_batch) (const unsigned char **m, size_t *mlen, cons
 		batchsize = (num > max_batch_size) ? max_batch_size : num;
 
 		/* generate r (scalars[batchsize+1]..scalars[2*batchsize] */
-		ed25519_randombytes_unsafe(batch.r, batchsize * 16);
+		ED25519_FN(ed25519_randombytes_unsafe) (batch.r, batchsize * 16);
 		r_scalars = &batch.scalars[batchsize + 1];
 		for (i = 0; i < batchsize; i++)
 			expand256_modm(r_scalars[i], batch.r[i], 16);
@@ -248,7 +248,7 @@ ED25519_FN(ed25519_sign_open_batch) (const unsigned char **m, size_t *mlen, cons
 
 			fallback:
 			for (i = 0; i < batchsize; i++) {
-				valid[i] = ed25519_sign_open(m[i], mlen[i], pk[i], RS[i]) ? 0 : 1;
+				valid[i] = ED25519_FN(ed25519_sign_open) (m[i], mlen[i], pk[i], RS[i]) ? 0 : 1;
 				ret |= (valid[i] ^ 1);
 			}
 		}
@@ -262,7 +262,7 @@ ED25519_FN(ed25519_sign_open_batch) (const unsigned char **m, size_t *mlen, cons
 	}
 
 	for (i = 0; i < num; i++) {
-		valid[i] = ed25519_sign_open(m[i], mlen[i], pk[i], RS[i]) ? 0 : 1;
+		valid[i] = ED25519_FN(ed25519_sign_open) (m[i], mlen[i], pk[i], RS[i]) ? 0 : 1;
 		ret |= (valid[i] ^ 1);
 	}
 


### PR DESCRIPTION
The ed25519_sign_open_batch function invokes randombytes_unsafe and
sign_open..., but if ED25519_SUFFIX is defined, those functions will
be compiled with different names.
