### PR TITLE
Fix a C++-related syntax error in ed25519.h

### DIFF
--- a/ed25519.h
+++ b/ed25519.h
@@ -24,7 +24,7 @@ void ed25519_randombytes_unsafe(void *out, size_t count);
 void curved25519_scalarmult_basepoint(curved25519_key pk, const curved25519_key e);
 
 #if defined(__cplusplus)
-};
+}
 #endif
 
 #endif // ED25519_H


### PR DESCRIPTION
The ending bracket in an `extern "C"` statement does not need a semicolon.
(This breaks compilation _at least_ for clang++.)
