### PR TITLE
ed25519-donna-portable.h:  Don't redefine ALIGN

### DIFF
--- a/ed25519-donna-portable.h
+++ b/ed25519-donna-portable.h
@@ -20,6 +20,7 @@
 	#include <sys/param.h>
 	#define DONNA_INLINE inline __attribute__((always_inline))
 	#define DONNA_NOINLINE __attribute__((noinline))
+	#undef ALIGN
 	#define ALIGN(x) __attribute__((aligned(x)))
 	#define ROTL32(a,b) (((a) << (b)) | ((a) >> (32 - b)))
 	#define ROTR32(a,b) (((a) >> (b)) | ((a) << (32 - b)))


### PR DESCRIPTION
This silences a macro redefinition warning.
