### PR TITLE
Fix resource leaks in fuzz

### DIFF
--- a/fuzz/fuzz-curve25519.c
+++ b/fuzz/fuzz-curve25519.c
@@ -72,8 +72,10 @@ prng(unsigned char *out, size_t bytes) {
 		}
 		if (fread(state, sizeof(state), 1, f) != 1) {
 			printf("read error on /dev/urandom\n");
+			fclose(f);
 			exit(1);
 		}
+		fclose(f);
 	#endif
 		init = 1;
 	}

--- a/fuzz/fuzz-ed25519.c
+++ b/fuzz/fuzz-ed25519.c
@@ -71,8 +71,10 @@ prng(unsigned char *out, size_t bytes) {
 		}
 		if (fread(state, sizeof(state), 1, f) != 1) {
 			printf("read error on /dev/urandom\n");
+			fclose(f);
 			exit(1);
 		}
+		fclose(f);
 	#endif
 		init = 1;
 	}


### PR DESCRIPTION
Add missing `fclose` calls for variable `f`